### PR TITLE
Included missing method GetTestSuiteAttachments on API for C# use.

### DIFF
--- a/src/TestLinkApi.NetCore/ITestLink.cs
+++ b/src/TestLinkApi.NetCore/ITestLink.cs
@@ -156,6 +156,9 @@ namespace TestLinkApi
         [XmlRpcMethod("tl.uploadTestSuiteAttachment", StructParams = true)]
         object uploadTestSuiteAttachment(string devKey, int testsuiteid, string filename, string fileType, string content, string title, string description);
 
+        [XmlRpcMethod("tl.getTestSuiteAttachments", StructParams = true)]
+        object getTestSuiteAttachments(string devKey, int testsuiteid);
+
         #endregion
 
         #region execution

--- a/src/TestLinkApi.NetCore/TestLink.cs
+++ b/src/TestLinkApi.NetCore/TestLink.cs
@@ -788,7 +788,28 @@ namespace TestLinkApi
             return result;
         }
 
+        /// <summary>
+        /// retrieve the attachments for a test suite
+        /// </summary>
+        /// <param name="testSuiteId"></param>
+        /// <returns></returns>
+        public List<Attachment> GetTestSuiteAttachments(int testSuiteId)
+        {
+            stateIsValid();
+            var o = proxy.getTestSuiteAttachments(devkey, testSuiteId);
+            handleErrorMessage(o);
+            var result = new List<Attachment>();
+            var olist = o as XmlRpcStruct;
+            if (olist != null)
+                foreach (XmlRpcStruct item in olist.Values)
+                {
+                    var a = TestLinkData.ToAttachment(item);
+                    result.Add(a);
+                }
 
+            return result;
+        }
+               
         #region getTestCasesForTestPlan
 
         /// <summary>


### PR DESCRIPTION
Included missing method on API for C# use.
Note: This method is available for Java use.